### PR TITLE
click on giornate done; add closure and page_interaction on web_scraping

### DIFF
--- a/giornate.py
+++ b/giornate.py
@@ -1,19 +1,28 @@
 from lxml import html
 import pandas as pd
 from web_scraping_etl import SeleniumETL
+from selenium.webdriver.support import expected_conditions
+from selenium.webdriver.common.by import By
+from time import sleep
 
 
 class Giornate(SeleniumETL):
 
     def __init__(self, **kwargs):
         super(Giornate, self).__init__(**kwargs)
-        print(self.url)
-        print(self.xpath)
+
+    def page_interaction(self):
+        counter = 0
+        element = self.driver.find_element_by_id("tournament-page-results-more")
+        cond = expected_conditions.invisibility_of_element_located((By.ID, "tournament-page-results-more"))
+        while cond(self.driver) is False:
+            element.click()
+            counter += 1
+            print('click n {}'.format(counter))
+            sleep(5)
 
     def load(self):
-        table = self.element[0].getchildren()[0]
+        element = self.tree.xpath(self.xpath)
+        table = element[0]
         raw_html = html.tostring(table)
         self.df = pd.read_html(raw_html)[0]
-
-
-

--- a/web_scraping_etl.py
+++ b/web_scraping_etl.py
@@ -5,6 +5,7 @@ from selenium import webdriver
 from lxml import html
 from lxml.html import soupparser
 
+
 class WebScrapingETL(metaclass=abc.ABCMeta):
 
     def __init__(self, url=None, xpath=None, **kwargs):
@@ -15,6 +16,7 @@ class WebScrapingETL(metaclass=abc.ABCMeta):
         self.extract()
         self.transform()
         self.load()
+        self.closure()
 
     @abstractmethod
     def extract(self):
@@ -28,6 +30,9 @@ class WebScrapingETL(metaclass=abc.ABCMeta):
     def load(self):
         pass
 
+    def closure(self):
+        pass
+
 
 class SeleniumETL(WebScrapingETL):
 
@@ -35,22 +40,29 @@ class SeleniumETL(WebScrapingETL):
         super(SeleniumETL, self).__init__(**kwargs)
         self.driver = driver
 
+    def closure(self):
+        self.driver.close()
+
     def extract(self):
         self.driver.get(self.url)
 
     def transform(self):
+        self.page_interaction()
         html_source = self.driver.page_source
         self.tree = html.fromstring(html_source)
-        self.element = self.tree.xpath(self.xpath)
+
+    def page_interaction(self):
+        pass
 
 
 class SoupHtmlETL(WebScrapingETL):
 
-    def __init__(self, user_agent=None, **kwargs):
+    def __init__(self, user_agent=None, soup=True, **kwargs):
         super(SoupHtmlETL, self).__init__(**kwargs)
         self.headers = requests.utils.default_headers()
         if user_agent:
             self.headers.update({'User-Agent': user_agent})
+        self.soup = soup
 
         def extract(self):
             self.html_source = requests.get(self.url, headers=self.headers)


### PR DESCRIPTION
**To** michelaievamio@gmail.com, andrea.caliandro@gmail.com

**What**
Solved the problem of grabbing the full table with all the "giornate" from www.diretta.it/calcio/italia/serie-a-2010-2011/risultati/.

A multiple click action on the element "tournament-page-results-more" was necessary to show the entire table.
To address it, we declared a new method `page_inetraction` into the class `SeleniumETL`, and implemented it in the child class `Giornate` in order to perform the clicks. 

**Test**
Tested on jupyter notebook
